### PR TITLE
fix: add missing confidence field for Commitment entities

### DIFF
--- a/scripts/kg_extractor.py
+++ b/scripts/kg_extractor.py
@@ -492,7 +492,8 @@ class EntityExtractor:
                     props['mistake_or_success'] = 'observation'
 
                 elif entity_type == 'Commitment':
-                    # Commitment 没有 confidence 字段
+                    # Commitment 没有 confidence 评估，使用默认值
+                    props['confidence'] = 0.5
                     props['description'] = item.get('description', '')
                     props['created_at'] = time_field
                     props['status'] = 'pending'


### PR DESCRIPTION
## Summary
- Fix KeyError when processing Commitment entities — missing `confidence` field now defaults to `0.5`

## Test Coverage
All new code paths have test coverage. Existing tests cover the entity extraction paths.

## Pre-Landing Review
No issues found.

## Greptile Review
No Greptile comments.

## TODOS
No TODO items completed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)